### PR TITLE
Set scala version to 2.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ lazy val buildSettings = Seq(
   organization := "com.ithaca",
   scalaOrganization := "org.typelevel",
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.11.8", "2.12.1"),
   name         := "libra"
 )


### PR DESCRIPTION
Set the scala version to `2.12.1` so that the `sbt compile` task works as normal, as raised in #8 .