### PR TITLE
Rename Unit to UnitOfMeasure

### DIFF
--- a/src/main/scala/libra/Unit.scala
+++ b/src/main/scala/libra/Unit.scala
@@ -1,4 +1,4 @@
 package libra
 
 /** Represents a unit of a given dimension */
-trait Unit[D]
+trait UnitOfMeasure[D]

--- a/src/main/scala/libra/imperial/package.scala
+++ b/src/main/scala/libra/imperial/package.scala
@@ -9,8 +9,8 @@ import libra.si.Time
 package object imperial {
 
   /** Time units */
-  trait Day extends Unit[Time]
-  trait Hour extends Unit[Time]
+  trait Day extends UnitOfMeasure[Time]
+  trait Hour extends UnitOfMeasure[Time]
 
   implicit def dayShow: Show[Day] = Show[Day]("days")
   implicit def hourShow: Show[Hour] = Show[Hour]("hours")

--- a/src/main/scala/libra/nonsi/package.scala
+++ b/src/main/scala/libra/nonsi/package.scala
@@ -12,9 +12,9 @@ package object nonsi {
   implicit def angleShow: Show[Angle] = Show[Angle]("∠")
 
   /** Angle units */
-  trait Degree extends Unit[Angle]
-  trait Arcminute extends Unit[Angle]
-  trait Arcsecond extends Unit[Angle]
+  trait Degree extends UnitOfMeasure[Angle]
+  trait Arcminute extends UnitOfMeasure[Angle]
+  trait Arcsecond extends UnitOfMeasure[Angle]
 
   implicit def degreeShow: Show[Degree] = Show[Degree]("degree")
   implicit def arcminuteShow: Show[Arcminute] = Show[Arcminute]("arcminute")

--- a/src/main/scala/libra/ops/base.scala
+++ b/src/main/scala/libra/ops/base.scala
@@ -23,22 +23,22 @@ object base {
     * @tparam F the unit to convert from
     * @tparam T the unit to convert to
     */
-  case class ConversionFactor[A, D, F <: Unit[D], T <: Unit[D]](val value: A)
+  case class ConversionFactor[A, D, F <: UnitOfMeasure[D], T <: UnitOfMeasure[D]](val value: A)
 
   /** Derived typeclass for the conversion factor from F to T
     *
     * Two conversions (from and to) are derived from a single conversion factor
     */
-  class Conversion[A, D, F <: Unit[D], T <: Unit[D]](val factor: A)
+  class Conversion[A, D, F <: UnitOfMeasure[D], T <: UnitOfMeasure[D]](val factor: A)
 
   object Conversion {
 
-    implicit def conversionTo[A, D, F <: Unit[D], T <: Unit[D]](
+    implicit def conversionTo[A, D, F <: UnitOfMeasure[D], T <: UnitOfMeasure[D]](
       implicit to: ConversionFactor[A, D, F, T]
     ): Conversion[A, D, F, T] =
       new Conversion(to.value)
 
-    implicit def conversionFrom[A, D, F <: Unit[D], T <: Unit[D]](
+    implicit def conversionFrom[A, D, F <: UnitOfMeasure[D], T <: UnitOfMeasure[D]](
       implicit to: ConversionFactor[A, D, F, T],
       ev0: Refute[ConversionFactor[A, D, T, F]],
       ev1: MultiplicativeGroup[A]

--- a/src/main/scala/libra/ops/dimensions.scala
+++ b/src/main/scala/libra/ops/dimensions.scala
@@ -24,7 +24,7 @@ object dimensions {
 
     implicit def multiplyMergedBase: Aux[HNil, HNil] = new MultiplyMerged[HNil] { type Out = HNil }
 
-    implicit def multiplyMergedRecurseValid[D, U <: Unit[_], LF <: Fraction[_, _], RF <: Fraction[_, _], TF <: Fraction[_, _],
+    implicit def multiplyMergedRecurseValid[D, U <: UnitOfMeasure[_], LF <: Fraction[_, _], RF <: Fraction[_, _], TF <: Fraction[_, _],
       Tail <: HList, OutTail <: HList](
       implicit ev0: fraction.Add.Aux[LF, RF, TF],
       ev1: fraction.Valid[TF],
@@ -35,7 +35,7 @@ object dimensions {
       }
 
 
-    implicit def multiplyMergedRecurseInvalid[D, U <: Unit[_], LF <: Fraction[_, _], RF <: Fraction[_, _], TF <: Fraction[_, _],
+    implicit def multiplyMergedRecurseInvalid[D, U <: UnitOfMeasure[_], LF <: Fraction[_, _], RF <: Fraction[_, _], TF <: Fraction[_, _],
       Tail <: HList, OutTail <: HList](
       implicit ev0: fraction.Add.Aux[LF, RF, TF],
       ev1: Refute[fraction.Valid[TF]],
@@ -45,7 +45,7 @@ object dimensions {
         type Out = OutTail
       }
 
-    implicit def multiplyMergedRecurseSingle[D, U <: Unit[_], F <: Fraction[_, _], Tail <: HList, OutTail <: HList](
+    implicit def multiplyMergedRecurseSingle[D, U <: UnitOfMeasure[_], F <: Fraction[_, _], Tail <: HList, OutTail <: HList](
       implicit ev: Aux[Tail, OutTail]
     ): Aux[FieldType[D, (U, F)] :: Tail, FieldType[D, (U, F)] :: OutTail] = 
       new MultiplyMerged[FieldType[D, (U, F)] :: Tail] {
@@ -80,7 +80,7 @@ object dimensions {
     implicit def invertBase: Aux[HNil, HNil] = new Invert[HNil] { 
       type Out = HNil
     }
-    implicit def invertRecurse[D, U <: Unit[_], F <: Fraction[_, _], NF <: Fraction[_, _], T <: HList, IT <: HList](
+    implicit def invertRecurse[D, U <: UnitOfMeasure[_], F <: Fraction[_, _], NF <: Fraction[_, _], T <: HList, IT <: HList](
       implicit ev0: fraction.Negate.Aux[F, NF],
       ev1: Aux[T, IT]): Aux[Term[D, U, F] :: T, Term[D, U, NF] :: IT] = new Invert[Term[D, U, F] :: T] {
       type Out = Term[D, U, NF] :: IT
@@ -115,7 +115,7 @@ object dimensions {
       type Out = HNil
     }
 
-    implicit def dimensionsPowerRecurseValid[P <: XInt, D, U <: Unit[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList, Out0 <: HList](
+    implicit def dimensionsPowerRecurseValid[P <: XInt, D, U <: UnitOfMeasure[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList, Out0 <: HList](
       implicit ev0: fraction.Multiply.Aux[F, Fraction[P, 1], PF],
       ev1: Aux[P, T, TOut],
       ev2: fraction.Valid[PF]
@@ -123,7 +123,7 @@ object dimensions {
       type Out = Term[D, U, PF] :: TOut
     }
 
-    implicit def dimensionsPowerRecurseInvalid[P <: XInt, D, U <: Unit[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList, Out0 <: HList](
+    implicit def dimensionsPowerRecurseInvalid[P <: XInt, D, U <: UnitOfMeasure[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList, Out0 <: HList](
       implicit ev0: fraction.Multiply.Aux[F, Fraction[P, 1], PF],
       ev1: Aux[P, T, TOut],
       ev2: Refute[fraction.Valid[PF]]
@@ -144,7 +144,7 @@ object dimensions {
       type Out = HNil
     }
 
-    implicit def dimensionsRootRecurse[P <: XInt, D, U <: Unit[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList](
+    implicit def dimensionsRootRecurse[P <: XInt, D, U <: UnitOfMeasure[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList](
       implicit ev0: fraction.Multiply.Aux[F, Fraction[1, P], PF],
       ev1: Aux[P, T, TOut],
       ev2: fraction.Valid[PF]
@@ -152,7 +152,7 @@ object dimensions {
       type Out = Term[D, U, PF] :: TOut
     }
 
-    implicit def dimensionsRootRecurseInvalid[P <: XInt, D, U <: Unit[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList](
+    implicit def dimensionsRootRecurseInvalid[P <: XInt, D, U <: UnitOfMeasure[_], F <: Fraction[_, _], PF <: Fraction[_, _], T <: HList, TOut <: HList](
       implicit ev0: fraction.Multiply.Aux[F, Fraction[1, P], PF],
       ev1: Aux[P, T, TOut],
       ev2: Refute[fraction.Valid[PF]]
@@ -161,15 +161,15 @@ object dimensions {
     }
   }
 
-  trait ConvertTo[A, UT <: Unit[_], H <: HList] {
+  trait ConvertTo[A, UT <: UnitOfMeasure[_], H <: HList] {
     type Out <: HList
     def apply(a: A): A
   }
 
   object ConvertTo {
-    type Aux[A, UT <: Unit[_], H <: HList, Out0 <: HList] = ConvertTo[A, UT, H] { type Out = Out0 }
+    type Aux[A, UT <: UnitOfMeasure[_], H <: HList, Out0 <: HList] = ConvertTo[A, UT, H] { type Out = Out0 }
 
-    implicit def dimensionConvertTo[A, D, UF <: Unit[D], NF <: Singleton with Int, DF <: Singleton with Int, UT <: Unit[D], T <: HList]
+    implicit def dimensionConvertTo[A, D, UF <: UnitOfMeasure[D], NF <: Singleton with Int, DF <: Singleton with Int, UT <: UnitOfMeasure[D], T <: HList]
     (implicit conversion: base.Conversion[A, D, UF, UT],
       ev3: Field[A],
       ev4: NRoot[A],
@@ -181,7 +181,7 @@ object dimensions {
         def apply(a: A): A = conversion.factor.pow(n: Int).nroot(d) * a
       }
 
-    implicit def dimensionConvertToRecurse[A, U <: Unit[_], H, T <: HList, TOut <: HList](
+    implicit def dimensionConvertToRecurse[A, U <: UnitOfMeasure[_], H, T <: HList, TOut <: HList](
       implicit ev: Aux[A, U, T, TOut]
     ): Aux[A, U, H :: T, H :: TOut] =
       new ConvertTo[A, U, H :: T] {
@@ -200,7 +200,7 @@ object dimensions {
       def apply(): String = ""
     }
 
-    implicit def dimensionsShowDimensionRecurse[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowDimensionRecurse[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showDimension: base.Show[D], showTail: ShowDimension[T],
       ev0: Require[FD != 1],
       numerator: SafeInt[FN],
@@ -209,7 +209,7 @@ object dimensions {
         def apply(): String = s"${showDimension()}^${(numerator: Int)}/${(denominator: Int)} ${showTail()}"
       }
 
-    implicit def dimensionsShowDimensionRecurse1[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowDimensionRecurse1[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showDimension: base.Show[D], showTail: ShowDimension[T],
       ev0: Require[FD == 1], ev1: LowPriority,
       numerator: SafeInt[FN]) =
@@ -217,7 +217,7 @@ object dimensions {
         def apply(): String = s"${showDimension()}^${(numerator: Int)} ${showTail()}"
       }
 
-    implicit def dimensionsShowDimensionRecurse2[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowDimensionRecurse2[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showDimension: base.Show[D], showTail: ShowDimension[T],
       ev0: Require[FD == 1], ev1: Require[FN == 1],
       numerator: SafeInt[FN],
@@ -238,7 +238,7 @@ object dimensions {
       def apply(): String = ""
     }
 
-    implicit def dimensionsShowUnitRecurse[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowUnitRecurse[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showUnit: base.Show[U], showTail: ShowUnit[T],
       ev0: Require[FD != 1],
       numerator: SafeInt[FN],
@@ -247,7 +247,7 @@ object dimensions {
         def apply(): String = s"${showUnit()}^${(numerator: Int)}/${(denominator: Int)} ${showTail()}"
       }
 
-    implicit def dimensionsShowUnitRecurse1[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowUnitRecurse1[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showUnit: base.Show[U], showTail: ShowUnit[T],
       ev0: Require[FD == 1], ev1: LowPriority,
       numerator: SafeInt[FN],
@@ -256,7 +256,7 @@ object dimensions {
         def apply(): String = s"${showUnit()}^${(numerator: Int)} ${showTail()}"
       }
 
-    implicit def dimensionsShowUnitRecurse2[D, U <: Unit[_], FN <: XInt, FD <: XInt, T <: HList](
+    implicit def dimensionsShowUnitRecurse2[D, U <: UnitOfMeasure[_], FN <: XInt, FD <: XInt, T <: HList](
       implicit showUnit: base.Show[U], showTail: ShowUnit[T],
       ev0: Require[FD == 1], ev1: Require[FN == 1],
       numerator: SafeInt[FN],

--- a/src/main/scala/libra/ops/quantity.scala
+++ b/src/main/scala/libra/ops/quantity.scala
@@ -146,14 +146,14 @@ Right: ${R}""")
       }
   }
 
-  trait ConvertTo[Q <: Quantity[_, _], UT <: Unit[_]] extends DepFn1[Q] {
+  trait ConvertTo[Q <: Quantity[_, _], UT <: UnitOfMeasure[_]] extends DepFn1[Q] {
     type Out <: Quantity[_, _]
   }
 
   object ConvertTo {
-    type Aux[Q <: Quantity[_, _], UT <: Unit[_], Out0 <: Quantity[_, _]] = ConvertTo[Q, UT] { type Out = Out0 }
+    type Aux[Q <: Quantity[_, _], UT <: UnitOfMeasure[_], Out0 <: Quantity[_, _]] = ConvertTo[Q, UT] { type Out = Out0 }
 
-    implicit def quantityConvertTo[A, U <: Unit[_], D <: HList, DOut <: HList](
+    implicit def quantityConvertTo[A, U <: UnitOfMeasure[_], D <: HList, DOut <: HList](
       implicit to: dimensions.ConvertTo.Aux[A, U, D, DOut]
     ): Aux[Quantity[A, D], U, Quantity[A, DOut]] = new ConvertTo[Quantity[A, D], U] {
       type Out = Quantity[A, DOut]

--- a/src/main/scala/libra/package.scala
+++ b/src/main/scala/libra/package.scala
@@ -9,10 +9,10 @@ package object libra {
     * @tparam U the unit
     * 
     */
-  type Term[D, U <: Unit[_], E <: Fraction[_, _]] = shapeless.labelled.FieldType[D, (U, E)]
+  type Term[D, U <: UnitOfMeasure[_], E <: Fraction[_, _]] = shapeless.labelled.FieldType[D, (U, E)]
 
-  type TermValue[U <: Unit[_], E <: Fraction[_, _]] = (U, E)
+  type TermValue[U <: UnitOfMeasure[_], E <: Fraction[_, _]] = (U, E)
 
   /** Aliases a quantity with single unit */
-  type QuantityOf[A, D, U <: Unit[D]] = Quantity[A, Term[D, U, Fraction[1, 1]] :: HNil]
+  type QuantityOf[A, D, U <: UnitOfMeasure[D]] = Quantity[A, Term[D, U, Fraction[1, 1]] :: HNil]
 }

--- a/src/main/scala/libra/quantity.scala
+++ b/src/main/scala/libra/quantity.scala
@@ -221,7 +221,7 @@ case class Quantity[A, D <: HList](val value: A) extends AnyVal {
     */
   def ^[P <: Singleton with Int](pow: P)(implicit p: Power[Quantity[A, D], P]): p.Out = p(this)
 
-  def to[U <: Unit[_]](implicit to: ConvertTo[Quantity[A, D], U]): to.Out = to(this)
+  def to[U <: UnitOfMeasure[_]](implicit to: ConvertTo[Quantity[A, D], U]): to.Out = to(this)
 }
 
 object Quantity {

--- a/src/main/scala/libra/si/MetricUnit.scala
+++ b/src/main/scala/libra/si/MetricUnit.scala
@@ -3,4 +3,4 @@ package si
 
 import singleton.ops._
 
-trait MetricUnit[I <: XInt, D] extends Unit[D]
+trait MetricUnit[I <: XInt, D] extends UnitOfMeasure[D]

--- a/src/main/scala/libra/si/package.scala
+++ b/src/main/scala/libra/si/package.scala
@@ -50,9 +50,9 @@ package object si {
 
   type Ampere = MetricUnit[0, Current]
   type MilliAmpere = MetricUnit[-3, Current]
-  type Kelvin = Unit[Temperature]
-  type Mole = Unit[Amount]
-  type Candela = Unit[Intensity]
+  type Kelvin = UnitOfMeasure[Temperature]
+  type Mole = UnitOfMeasure[Amount]
+  type Candela = UnitOfMeasure[Intensity]
 
   implicit def lengthShow: Show[Length] = Show[Length]("L")
   implicit def massShow: Show[Mass] = Show[Mass]("M")
@@ -103,16 +103,16 @@ package object si {
     def am: QuantityOf[A, Length, Attometre] = Quantity(a)
   }
 
-  type VelocityQuantity[A, L <: Unit[Length], T <: Unit[Time]] =
+  type VelocityQuantity[A, L <: UnitOfMeasure[Length], T <: UnitOfMeasure[Time]] =
     Quantity[A, Term[Length, L, Fraction[1, 1]] :: Term[Time, T, Fraction[-1, 1]] :: HNil]
 
-  type AccelerationQuantity[A, L <: Unit[Length], T <: Unit[Time]] =
+  type AccelerationQuantity[A, L <: UnitOfMeasure[Length], T <: UnitOfMeasure[Time]] =
     Quantity[A, Term[Length, L, Fraction[1, 1]] :: Term[Time, T, Fraction[-2, 1]] :: HNil]
 
-  type MomentumQuantity[A, M <: Unit[Mass], L <: Unit[Length], T <: Unit[Time]] =
+  type MomentumQuantity[A, M <: UnitOfMeasure[Mass], L <: UnitOfMeasure[Length], T <: UnitOfMeasure[Time]] =
     Quantity[A, Term[Mass, M, Fraction[1, 1]] :: Term[Length, L, Fraction[1, 1]] :: Term[Time, T, Fraction[-1, 1]] :: HNil]
 
-  type ForceQuantity[A, M <: Unit[Mass], L <: Unit[Length], T <: Unit[Time]] =
+  type ForceQuantity[A, M <: UnitOfMeasure[Mass], L <: UnitOfMeasure[Length], T <: UnitOfMeasure[Time]] =
     Quantity[A, Term[Mass, M, Fraction[1, 1]] :: Term[Length, L, Fraction[1, 1]] :: Term[Time, T, Fraction[-2, 1]] :: HNil]
 
   implicit final class SIVelocityQuantityOps[A](val a: A) extends AnyVal {

--- a/src/main/tut/docs/rollYourOwn.md
+++ b/src/main/tut/docs/rollYourOwn.md
@@ -18,11 +18,11 @@ object catan {
   type Sheep
   type Time
   
-  type Rock = Unit[Stone]
-  type Log = Unit[Wood]
-  type Bushel = Unit[Wheat]
-  type Flock = Unit[Sheep]
-  type Turn = Unit[Time]
+  type Rock = UnitOfMeasure[Stone]
+  type Log = UnitOfMeasure[Wood]
+  type Bushel = UnitOfMeasure[Wheat]
+  type Flock = UnitOfMeasure[Sheep]
+  type Turn = UnitOfMeasure[Time]
   
   
   //we ought to provide shows


### PR DESCRIPTION
Rename `Unit` to `UnitOfMeasure` as referenced in #43 